### PR TITLE
Adds vendor extensible extensions to Parameter

### DIFF
--- a/parameter.go
+++ b/parameter.go
@@ -59,6 +59,10 @@ type ParameterData struct {
 	AllowMultiple                           bool
 	DefaultValue                            string
 	CollectionFormat                        string
+
+	// Extensions/vendor extensions used to describe extra functionality
+	// (https://swagger.io/docs/specification/2-0/swagger-extensions/)
+	Extensions map[string]interface{}
 }
 
 // Data returns the state of the Parameter
@@ -69,6 +73,15 @@ func (p *Parameter) Data() ParameterData {
 // Kind returns the parameter type indicator (see const for valid values)
 func (p *Parameter) Kind() int {
 	return p.data.Kind
+}
+
+// AddExtension adds or updates a key=value pair to the extension map.
+func (p *Parameter) AddExtension(key string, value interface{}) *Parameter {
+	if p.data.Extensions == nil {
+		p.data.Extensions = map[string]interface{}{}
+	}
+	p.data.Extensions[key] = value
+	return p
 }
 
 func (p *Parameter) bePath() *Parameter {

--- a/parameter_test.go
+++ b/parameter_test.go
@@ -1,0 +1,15 @@
+package restful
+
+import (
+	"testing"
+)
+
+func TestParameter_AddExtension(t *testing.T) {
+	p := &Parameter{&ParameterData{Name: "name", Description: "desc"}}
+	extKey := "x-testing-add-extension"
+	p.AddExtension(extKey, "better work")
+
+	if _, ok := p.data.Extensions[extKey]; !ok {
+		t.Error("AddExtension should result in value being stored within the ParameterData Extensions map")
+	}
+}


### PR DESCRIPTION
Even though Open API supports extensions for parameters, the support was never enabled in `go-restful`'s parameter implementation. This adds support for that.

In order for this new field to serve its purpose, another PR will be opened on `go-restful-openapi` to copy valid extensions to the `spec.Parameter` instance.

Added to support dependent PR:
https://github.com/CrowdStrike/go-restful-openapi/pull/3

_Note: This is already fully implemented in our internal monorepo at CrowdStrike._